### PR TITLE
fix(typo): use Pointer kind type in NewValues

### DIFF
--- a/docs/guide/query-common-table-expressions.md
+++ b/docs/guide/query-common-table-expressions.md
@@ -77,7 +77,7 @@ Bun also provides [ValuesQuery](https://pkg.go.dev/github.com/uptrace/bun#Values
 building CTEs:
 
 ```go
-values := db.NewValues([]*Book{book1, book2})
+values := db.NewValues(&[]*Book{book1, book2})
 
 res, err := db.NewUpdate().
     With("_data", values).

--- a/docs/guide/query-update.md
+++ b/docs/guide/query-update.md
@@ -91,7 +91,7 @@ res, err := db.NewUpdate().
 To bulk-update books, you can use a [CTE](query-common-table-expressions.md):
 
 ```go
-values := db.NewValues([]*Book{book1, book2})
+values := db.NewValues(&[]*Book{book1, book2})
 
 res, err := db.NewUpdate().
 	With("_data", values).


### PR DESCRIPTION
Hi, if I'm not mistaken, there are ampersand characters missing in two of the NewValues examples

For reference: https://github.com/uptrace/bun/blob/master/internal/dbtest/query_test.go#L204